### PR TITLE
Added wipe functionality at many levels and getBlueprints

### DIFF
--- a/src/machinist/Blueprint.php
+++ b/src/machinist/Blueprint.php
@@ -47,6 +47,18 @@ class Blueprint {
 		unset($this->machinist);
 	}
 
+	
+	/**
+	 * Wipe all data in the data store from this blueprint
+	 * @param bool $truncate Will perform wipe via truncate when true.
+	 * Defaults to false.  The actual action performed will be based on the wipe
+	 * method of a blueprint's store
+	 */
+	public function wipe($truncate = false) {
+		$this->machinist->getStore($this->store)->wipe($this->getTable(), $truncate);
+	}
+
+
 	private function buildData($overrides) {
 		$store = $this->machinist->getStore($this->store);
 		$data = array();

--- a/src/machinist/Machinist.php
+++ b/src/machinist/Machinist.php
@@ -65,6 +65,18 @@ class Machinist {
 	}
 
 	/**
+	 * Wipe all data in the data store from all blueprints
+	 * @param bool $truncate Will perform wipe via truncate when true.
+	 * Defaults to false.  The actual action performed will be based on the wipe
+	 * method of a blueprint's store
+	 */
+	public function wipeAll($truncate = false) {
+		foreach ($this->blueprints as $blueprint) {
+			$blueprint->wipe($truncate);
+		}
+	}
+
+	/**
 	 * Will create a new blueprint if one does not exist with the provided name. Otherwise  the existing one will
 	 * be returned. If no table name is provided, the name of the blueprint is used as the name. The default fields
 	 * will only be used in the case of a new blueprint.

--- a/src/machinist/driver/SqlStore.php
+++ b/src/machinist/driver/SqlStore.php
@@ -11,6 +11,7 @@ abstract class SqlStore implements Store {
 	public function __construct(\PDO $pdo) {
 		$this->pdo = $pdo;
 	}
+
 	public function insert($table, $data) {
 		$query = 'INSERT INTO '.$table.' ('.join(',', array_keys($data)).') VALUES('.trim(str_repeat('?,', count($data)),',').')';
 		$stmt = $this->pdo()->prepare($query);
@@ -23,6 +24,21 @@ abstract class SqlStore implements Store {
 		$query = $this->pdo()->prepare('SELECT * from '.$table.' WHERE '.$primary_key.' = ?');
 		$query->execute(array($key));
 		return $query->fetch(\PDO::FETCH_OBJ);
+	}
+
+	/**
+	 * Wipe all data in the data store for the provided table
+	 * @param string $table Name of table to remove all data
+	 * @param bool $truncate Will use truncate to delete data from table when set
+	 * to true
+	 */
+	public function wipe($table, $truncate) {
+		if ($truncate) {
+			$query = 'TRUNCATE TABLE '.$table;
+		} else {
+			$query = 'DELETE FROM '.$table;
+		}
+		return $this->pdo->exec($query);
 	}
 
 	/**

--- a/src/machinist/driver/Sqlite.php
+++ b/src/machinist/driver/Sqlite.php
@@ -6,7 +6,7 @@ use machinist\driver\SqlStore;
  * SQLite Specific store support.
  */
 class Sqlite extends SqlStore implements Store {
-   	public function primaryKey($table)
+	public function primaryKey($table)
 	{
 		$stmt = $this->pdo()->prepare("SELECT * FROM sqlite_master WHERE type='table' AND name=:name");
         $stmt->execute(array(':name' => $table));
@@ -19,12 +19,22 @@ class Sqlite extends SqlStore implements Store {
 		}
 	}
 
-    public function columns($table) {
-        $stmt = $this->_pdo->query("PRAGMA table_info($table)");
-        $columns = array();
-        while($row = $stmt->fetch()) {
-            $columns[] = $row['name'];
-        }
-        return $columns;
-    }
+	public function columns($table) {
+			$stmt = $this->_pdo->query("PRAGMA table_info($table)");
+			$columns = array();
+			while($row = $stmt->fetch()) {
+					$columns[] = $row['name'];
+			}
+			return $columns;
+	}
+
+	/**
+	 * Wipe all data in the data store for the provided table
+	 * @param string $table Name of table to delete all rows
+	 * @param bool $truncate SQLite does not support truncate
+	 */
+	public function wipe($table, $truncate) {
+		return parent::wipe($table, false);
+	}
+
 }

--- a/src/machinist/driver/Store.php
+++ b/src/machinist/driver/Store.php
@@ -6,5 +6,5 @@ interface Store {
 	public function columns($table);
 	public function insert($table, $data);
 	public function find($table, $key);
-
+	public function wipe($table, $truncate);
 }

--- a/test/machinist/BlueprintTest.php
+++ b/test/machinist/BlueprintTest.php
@@ -59,4 +59,19 @@ class BlueprintTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(true);
 
 	}
+
+	public function testWipeTellsStore() {
+		$table = 'test_table';
+		$bp = new Blueprint(
+			$this->machinist,
+			$table
+		);
+		
+		$bp->wipe(true);
+		Phake::verify($this->store)->wipe($table, true);
+
+		// I only need to Phake::verify; but, if we don't have an assertion, PHPUnit
+		// will cry
+		$this->assertTrue(true);
+	}
 }

--- a/test/machinist/MachinistTest.php
+++ b/test/machinist/MachinistTest.php
@@ -21,4 +21,21 @@ class MachinistTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains($bp1, $bps);
 		$this->assertContains($bp2, $bps);
 	}
+
+	public function testWipeAllCallsWipeOnAllBlueprints() {
+		$bp1 = Phake::mock('\machinist\Blueprint');
+		$bp2 = Phake::mock('\machinist\Blueprint');
+		$machinist = \machinist\Machinist::instance();
+		$store = Phake::mock('\machinist\driver\Store');
+		$machinist->Store($store);
+		$machinist->addBlueprint('bp1', $bp1);
+		$machinist->addBlueprint('bp2', $bp2);
+		$machinist->wipeAll(true);
+		Phake::verify($bp1)->wipe(true);
+		Phake::verify($bp2)->wipe(true);
+
+		// I only need to Phake::verify; but, if we don't have an assertion, PHPUnit
+		// will cry
+			$this->assertTrue(true);
+	}
 }

--- a/test/machinist/driver/MysqlTest.php
+++ b/test/machinist/driver/MysqlTest.php
@@ -43,4 +43,21 @@ class MysqlTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals("stupid", $row->name);
 	}
 
+	public function testEmptyNoTruncateDeletesRows() {
+		$id = $this->driver->insert('stuff', array('name' => 'stupid'));
+		$row = $this->driver->find('stuff', $id);
+		$this->assertNotEmpty($row);
+		$this->driver->wipe('stuff', false);
+		$row = $this->driver->find('stuff', $id);
+		$this->assertEmpty($row);
+	}
+
+	public function testEmptyTruncateDeletesRows() {
+		$id = $this->driver->insert('stuff', array('name' => 'stupid'));
+		$row = $this->driver->find('stuff', $id);
+		$this->assertNotEmpty($row);
+		$this->driver->wipe('stuff', true);
+		$row = $this->driver->find('stuff', $id);
+		$this->assertEmpty($row);
+	}
 }

--- a/test/machinist/driver/SqliteTest.php
+++ b/test/machinist/driver/SqliteTest.php
@@ -47,4 +47,22 @@ class SqliteTest extends PHPUnit_Framework_TestCase {
 		$row = $this->driver->find('stuff', $id);
 		$this->assertEquals("stupid", $row->name);
 	}
+
+	public function testEmptyNoTruncateDeletesRows() {
+		$id = $this->driver->insert('stuff', array('name' => 'stupid'));
+		$row = $this->driver->find('stuff', $id);
+		$this->assertNotEmpty($row);
+		$this->driver->wipe('stuff', false);
+		$row = $this->driver->find('stuff', $id);
+		$this->assertEmpty($row);
+	}
+
+	public function testEmptyTruncateDeletesRows() {
+		$id = $this->driver->insert('stuff', array('name' => 'stupid'));
+		$row = $this->driver->find('stuff', $id);
+		$this->assertNotEmpty($row);
+		$this->driver->wipe('stuff', true);
+		$row = $this->driver->find('stuff', $id);
+		$this->assertEmpty($row);
+	}
 }


### PR DESCRIPTION
Added wipe functionality at the Machinist, Blueprint and Store levels.  This will allow for resetting data for testing.  It allows for truncate and delete.
Add getBlueprints() to return an associative array of all Blueprints by name registered with Machinist.
