### PR TITLE
Test PDO config abstraction

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,4 +21,10 @@
 			<directory>src</directory>
 		</whitelist>
 	</filter>
+	<php>
+		<env name="SQLite_Driver_DSN" value="sqlite::memory:"/>
+		<env name="MySQL_Driver_DSN" value="mysql:host=localhost"/>
+		<env name="MySQL_Driver_User" value="root"/>
+		<env name="MySQL_Driver_Password" value=""/>
+	</php>
 </phpunit>

--- a/test/machinist/driver/MysqlTest.php
+++ b/test/machinist/driver/MysqlTest.php
@@ -6,7 +6,10 @@ class MysqlTest extends PHPUnit_Framework_TestCase {
 	private $driver;
 	private $pdo;
 	public function setUp() {
-		$this->pdo = Phake::partialMock('PDO', 'mysql:host=localhost', 'root');
+		$this->pdo = Phake::partialMock('PDO',
+						$_ENV['MySQL_Driver_DSN'],
+						$_ENV['MySQL_Driver_User'],
+						$_ENV['MySQL_Driver_Password']);
 		$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		$this->pdo->exec('CREATE DATABASE IF NOT EXISTS `machinist_test`;');
 		$this->pdo->exec('USE `machinist_test`;');
@@ -14,10 +17,10 @@ class MysqlTest extends PHPUnit_Framework_TestCase {
 		$this->pdo->exec('create table `stuff` ( `id` INTEGER PRIMARY KEY AUTO_INCREMENT, `name` varchar(100) );');
 		$this->pdo->exec('DROP TABLE IF EXISTS `some_stuff`;');
 		$this->pdo->exec('CREATE TABLE `some_stuff` (
-`some_id` int(10) unsigned NOT NULL,
-`stuff_id` int(10) unsigned NOT NULL,
-`name` VARCHAR(100),
-PRIMARY KEY (`some_id`,`stuff_id`));');
+												`some_id` int(10) unsigned NOT NULL,
+												`stuff_id` int(10) unsigned NOT NULL,
+												`name` VARCHAR(100),
+												PRIMARY KEY (`some_id`,`stuff_id`));');
 		$this->pdo->exec('DROP TABLE IF EXISTS `group`;');
 		$this->pdo->exec('create table `group` ( `id` INTEGER PRIMARY KEY AUTO_INCREMENT, `name` VARCHAR(255));');
 

--- a/test/machinist/driver/SqliteTest.php
+++ b/test/machinist/driver/SqliteTest.php
@@ -1,17 +1,18 @@
 <?php
+
 use \machinist\driver\SqlStore;
 use \machinist\driver\Sqlite;
-class SqliteTest extends PHPUnit_Framework_TestCase {
+
+class SqliteTest extends PHPUnit_Framework_TestCase
+{
+
 	private $driver;
+
 	private $pdo;
 
 	public function setUp() {
-		if (file_exists('test.db')) {
-			unlink('test.db');
-		}
-	    $this->pdo = Phake::partialMock('PDO', "sqlite::memory:");
-//		$this->pdo = new PDO("sqlite:test.db");
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+		$this->pdo = Phake::partialMock('PDO', $_ENV['SQLite_Driver_DSN']);
+		$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		$this->pdo->exec('DROP TABLE IF EXISTS `stuff`;');
 		$this->pdo->exec('create table `stuff` ( `id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` varchar(100) );');
 		$this->pdo->exec('DROP TABLE IF EXISTS `some_stuff`;');
@@ -38,7 +39,8 @@ class SqliteTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testSqlStoreGetsInstance() {
-		$this->assertInstanceOf('\machinist\driver\Sqlite', SqlStore::fromPdo($this->pdo));
+		$this->assertInstanceOf('\machinist\driver\Sqlite',
+						SqlStore::fromPdo($this->pdo));
 	}
 
 	public function testGetPrimaryKey() {
@@ -89,7 +91,6 @@ class SqliteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($row[0]->id, $id);
 	}
 
-
 	public function testFindCompoundPrimareyKey() {
 		$ids = $this->driver->primaryKey('some_stuff');
 		$this->assertEquals(array('some_id', 'stuff_id'), $ids);
@@ -131,4 +132,5 @@ class SqliteTest extends PHPUnit_Framework_TestCase {
 		$cols = $this->driver->columns('stuff');
 		$this->assertEquals(array('id', 'name'), $cols);
 	}
+
 }


### PR DESCRIPTION
We needed to move the connection configuration for testing into the PHPUnit config file to allow for different connection options without modifying the test code.  Change discussed with Stephan as he was the one with the issue.
