### PR TITLE
Allow mysql store wipe to wipe tables that have foreign key constraints

### DIFF
--- a/src/DerpTest/Machinist/Store/Mysql.php
+++ b/src/DerpTest/Machinist/Store/Mysql.php
@@ -99,4 +99,3 @@ class Mysql extends SqlStore
         }
     }
 }
-

--- a/test/DerpTest/Machinist/Store/MysqlTest.php
+++ b/test/DerpTest/Machinist/Store/MysqlTest.php
@@ -30,7 +30,6 @@ class MysqlTest extends PHPUnit_Framework_TestCase
         $this->pdo->exec('DROP TABLE IF EXISTS `nopk`;');
         $this->pdo->exec('create table `nopk` ( `id` INTEGER, `name` VARCHAR(255));');
 
-
         $this->pdo->exec('DROP TABLE IF EXISTS `fkey`;');
         $this->pdo->exec('CREATE TABLE `fkey` 
                                         ( `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
 MysqlStore is unable to wipe a table with foreign key constraint. I have added a test for this condition.
